### PR TITLE
Update spec and explainer for SANACLAP and exclusion API.

### DIFF
--- a/scroll-anchoring/explainer.md
+++ b/scroll-anchoring/explainer.md
@@ -208,10 +208,21 @@ anchor to such an element.)
 There is an open question of whether to skip absolute-positioned elements
 unconditionally.
 
-The argument in favor is that an absolute-positioned element is not affected by
-its in-flow siblings.  If static-positioned element A is followed by
-absolute-positioned element B, changes in the size of A do not move B, so
-anchoring to B isn't useful.
+Arguments in favor:
+
+* In the simplest case, an absolute-positioned element is not affected by
+  its in-flow siblings.  That is, if static-positioned element A is followed by
+  absolute-positioned element B, changes in the size of A do not move B, so
+  anchoring to B isn't useful.
+
+* A website that implements a fixed header as an absolute-positioned element
+  updated on scroll events will see no benefit from scroll anchoring if we
+  anchor to that element (adjustments from the header's movement are suppressed
+  under SANACLAP).  If the anchor node selection algorithm skips the element,
+  it will anchor to something in the main content permitting useful adjustments.
+
+  (The algorithm already skips fixed-position elements, which are a more natural
+  way of implementing fixed headers.)
 
 Counter-arguments:
 

--- a/scroll-anchoring/explainer.md
+++ b/scroll-anchoring/explainer.md
@@ -85,9 +85,9 @@ one of its ancestors.  For example, a map panning interface might update a CSS
 transform in response to mouse movements, or a sticky-header implementation
 might adjust padding on the body element.
 
-The SANACLAP principle ("suppress if anchor node ancestor changed a
-layout-affecting property") aims to suppress these undesired scroll anchoring
-adjustments.
+The SANACLAP principle ("**s**uppress if **a**nchor **n**ode **a**ncestor
+**c**hanged a **l**ayout-**a**ffecting **p**roperty") aims to suppress these
+undesired scroll anchoring adjustments.
 
 Under the SANACLAP principle, if the anchor node, or any ancestor of the anchor
 node up to and including the scrollable element (or document), has any of a

--- a/scroll-anchoring/explainer.md
+++ b/scroll-anchoring/explainer.md
@@ -170,6 +170,14 @@ The current implementation treats all of these as layout-affecting for SANACLAP
 purposes, but the web compatibility issues that motivated SANACLAP require
 suppression for only a small subset of these properties.
 
+In particular, the properties that relate directly to positioning and the CSS
+box model are more important than the properties that relate to text rendering
+or obscure layout features.
+
+On the other hand, a principled approach of "anything that can affect a
+descendant's computed position" has more conceptual simplicity, if this can be
+feasibly incorporated into a spec.
+
 #### Separating Opt Out and Exclusion APIs
 
 The `overflow-anchor` property is in a way doing double-duty as an opt out for

--- a/scroll-anchoring/explainer.md
+++ b/scroll-anchoring/explainer.md
@@ -20,7 +20,7 @@ follow the movement of visible page elements.
 
 ## Draft Spec
 
-[Draft spec](https://cdn.rawgit.com/ymalik/interventions/master/scroll-anchoring/spec.html)
+[Draft spec](https://cdn.rawgit.com/WICG/interventions/master/scroll-anchoring/spec.html)
 
 ## Design
 
@@ -58,8 +58,9 @@ document or an element with scrollable overflow) is as follows:
 
 * For each element E encountered by the walk,
 
-    - If E is position: fixed, or if E is position: absolute and E's containing
-      block is an ancestor of the scrollable area, skip over E and its
+    - If E is `position: fixed`, or if E is `position: absolute` and E's
+      containing block is an ancestor of the scrollable area, or if E has
+      `overflow-anchor: none` (see Exclusion API), skip over E and its
       descendents.
 
     - Otherwise, compare its bounds to the scrollable area's visible region.
@@ -76,37 +77,152 @@ document or an element with scrollable overflow) is as follows:
           nodes in this case to avoid the failure mode of content being inserted
           inside the anchor node but outside the viewport.)
 
-## Opt Out API
+## SANACLAP
+
+Initial testing revealed that scroll anchoring often performed undesired scroll
+adjustments in response to changes in the computed style of the anchor node or
+one of its ancestors.  For example, a map panning interface might update a CSS
+transform in response to mouse movements, or a sticky-header implementation
+might adjust padding on the body element.
+
+The SANACLAP principle ("suppress if anchor node ancestor changed a
+layout-affecting property") aims to suppress these undesired scroll anchoring
+adjustments.
+
+Under the SANACLAP principle, if the anchor node, or any ancestor of the anchor
+node up to and including the scrollable element (or document), has any of a
+certain set of CSS properties modified (the "layout-affecting properties"), any
+scroll anchoring adjustment that would have resulted from that modification is
+suppressed.
+
+The exact set of properties that are considered layout-affecting for the purpose
+of scroll anchoring is subject to change, but should at minimum include:
+
+* offset properties (left, top, right, bottom)
+* margin properties
+* padding properties
+* border-width properties
+* width, height, min-width, min-height, max-width, max-height
+* position, display, float, clear, overflow, transform
+
+## Exclusion / Opt Out API
 
 Scroll anchoring aims to be the default mode of behavior when launched, so that
-users benefit from it even on legacy content.  To allow web developers to
-disable scroll anchoring in part or all of a webpage we propose a CSS property
-`overflow-anchor` which applies to scrollable elements and supports the
-following values:
+users benefit from it even on legacy content, but we also want to give
+developers control over the feature if and when they need it.
 
-* `overflow-anchor: visible` causes a scrollable area to follow the content
-  within its viewport, using the scroll anchoring algorithm described in this
-  proposal.
+In particular, developers should be able to use CSS
 
-* `overflow-anchor: none` causes a scrollable area to maintain its absolute
-  scroll position when content changes.  This was the default behavior prior to
-  the introduction of scroll anchoring.
+* to disable scroll anchoring in part or all of a webpage (opt out), or
+* to exclude portions of the DOM from the anchor node selection algorithm
+  (exclusion).
 
-* `overflow-anchor: auto` invokes the user agent's default behavior for the
-  scrollable area.  With the launch of scroll anchoring this will be equivalent
-  to `viewport`, but is subject to future modification.
+We propose a CSS property `overflow-anchor` whose values have the following
+meaning for some element E:
 
-The behavior of the document-level scrollable area is based on the computed
-`overflow-anchor` style of the viewport-defining element (`html` or `body`).
+* `overflow-anchor: visible` declares that the DOM subtree rooted at E is
+  eligible to participate in the anchor node selection algorithm for any
+  scrollable area created by E or an ancestor of E.
+
+* `overflow-anchor: none` declares that the DOM subtree rooted at E should be
+  skipped by the anchor node selection algorithm for any scrollable area created
+  by E or an ancestor of E.
+
+* `overflow-anchor: auto` invokes the user agent's default behavior.  With the
+  launch of scroll anchoring this will be equivalent to `visible`, but is
+  subject to future modification.
+
+Note the following implications of the above semantics:
+
+* If `overflow-anchor: none` is applied to a descendant D of a scroller S, then
+  S will skip over D when selecting an anchor node, but can still perform scroll
+  anchoring adjustments based on anchor nodes outside of D.
+
+* If `overflow-anchor: none` is applied to a scroller S, then S will not perform
+  any scroll anchoring adjustments.
+
+* If `overflow-anchor: none` is applied to the root element (`html`), the
+  document-level scrollable area will not perform any scroll anchoring
+  adjustments.
 
 The `overflow-anchor` property is also proposed (with different values) for
 [CSS Sticky Scrollbars](http://tabatkins.github.io/specs/css-sticky-scrollbars/).
 This feature is distinct from scroll anchoring, but shares the notion of
 adjusting scroll position in response to content changes.
 
-The `overflow-anchor` property is not inherited.
+The `overflow-anchor` property is not inherited (but the effect of skipping a
+subtree in the anchor node selection algorithm bears a resemblance to property
+inheritance).
 
 ## Open Issues
+
+#### Definition of Layout-Affecting Property
+
+We need some definition of the set of properties that are considered
+layout-affecting for SANACLAP purposes.
+
+The full set of CSS properties that can
+affect the position of an element is complex and messy to enumerate.
+([Here](https://docs.google.com/spreadsheets/d/1iyg8udD-QNwv9sUja7vDBJI6MdKmFwczfvwwW2BAEzg/edit)
+is an attempt to do this based on the Blink layout invalidation code.)
+
+The current implementation treats all of these as layout-affecting for SANACLAP
+purposes, but the web compatibility issues that motivated SANACLAP require
+suppression for only a small subset of these properties.
+
+#### Separating Opt Out and Exclusion APIs
+
+The `overflow-anchor` property is in a way doing double-duty as an opt out for
+scrollable elements and an exclusion mechanism for subtrees within a scrollable
+element's content.
+
+Another option would be to use two separate CSS properties for this.
+
+#### Opt In for Simpler Anchoring
+
+SANACLAP adds significant complexity to the behavior of scroll anchoring, and
+additional heuristics may still be needed for web compatibility.
+
+There may be value in letting web developers opt in to a simpler and more
+aggressive version of scroll anchoring that does not include compatibility
+heuristics.
+
+This could be done through another value for the `overflow-anchor` property.
+
+#### Anchoring to Absolute-Positioned Elements
+
+The current anchor node selection algorithm has no special treatment for
+absolute-positioned elements unless their containing block is outside the
+scroller.  (An absolute-positioned element whose containing block is outside
+the scroller is not part of the scrolling content, so it is clearly futile to
+anchor to such an element.)
+
+There is an open question of whether to skip absolute-positioned elements
+unconditionally.
+
+The argument in favor is that an absolute-positioned element is not affected by
+its in-flow siblings.  If static-positioned element A is followed by
+absolute-positioned element B, changes in the size of A do not move B, so
+anchoring to B isn't useful.
+
+Counter-arguments:
+
+* An absolute-positioned element in a relative-positioned container can be
+  affected by in-flow siblings of the container.
+
+* An absolute-positioned element may have in-flow descendants that benefit from
+  scroll anchoring.  In particular, many websites have a high-level
+  absolute-positioned wrapper around all of the meaningful content.
+
+* There are no known web compatibility issues that are solved by skipping
+  absolute-positioned elements.  (Prior to SANACLAP this was not the case, but
+  SANACLAP solved those issues in a more generic way and was needed for other
+  reasons.)
+
+* Developer predictability and interoperability are best served by minimizing
+  "special cases".  Skipping absolute-positioned elements would be a surprising
+  quirk that contributes (albeit incrementally) to the complexity of the
+  feature.
 
 #### History Scroll Restoration
 
@@ -136,6 +252,10 @@ If the DOM changes made by a scroll event handler alter the position of the
 anchor node, we easily encounter feedback loops in which scroll anchoring and
 the scroll event handler trigger each other ad infinitum.  This is an
 undesirable user experience.
+
+The SANACLAP principle eliminates many, but not all, of the web compatibility
+issues that arise from scroll event handler feedback loops.  Solving the
+remaining cases is an in-progress discussion.
 
 ## Implementation Status
 

--- a/scroll-anchoring/spec.html
+++ b/scroll-anchoring/spec.html
@@ -230,6 +230,10 @@
             to <code>visible</code>, but is subject to future modification.
         </li>
       </ul>
+      <p class="issue">
+        The pairing of <code>visible</code> with <code>none</code> is awkward.
+        We should come up with better names for these values.
+      </p>
       <div class="note">
         The <code>overflow-anchor</code> property is also proposed (with different values) for
         <a href="http://tabatkins.github.io/specs/css-sticky-scrollbars/">CSS Sticky Scrollbars</a>.

--- a/scroll-anchoring/spec.html
+++ b/scroll-anchoring/spec.html
@@ -188,9 +188,9 @@
           the anchor node has moved. These are:
           <ul>
             <li>
-              When the DOM changes that caused the adjustment include changes to the
-              computed values of properties affecting the position of elements, on
-              elements in the path from the anchor node to the scrollable element (or
+              When the DOM changes that caused the adjustment include any change to the
+              computed value of a property affecting the position of elements, on any
+              element in the path from the anchor node to the scrollable element (or
               document), inclusive of both.
               <p class="issue">
                 Need a clearer specification of which properties trigger this condition.

--- a/scroll-anchoring/spec.html
+++ b/scroll-anchoring/spec.html
@@ -90,7 +90,15 @@
           The <dfn id="anchoring-algorithm">algorithm to select an anchor node for a scrollable area </dfn>(either a
           document or an element with scrollable overflow) is as follows:
           <ol>
-            <li>Walk the DOM within the <a href="https://drafts.csswg.org/cssom-view/#scrolling-box">scrollable area</a>.</li>
+            <li>
+              If the scrollable area is created by an element whose computed value of the
+              <a href="#overflow-anchor">overflow-anchor</a> property is
+              <a href="#overflow-anchor-none">none</a>, then do not select an anchor node.
+            </li>
+            <li>
+              Otherwise, walk the DOM within the
+              <a href="https://drafts.csswg.org/cssom-view/#scrolling-box">scrollable area</a>.
+            </li>
             <li>
               For each element E encountered by the walk
               <ol>
@@ -126,16 +134,13 @@
               E's computed value of the <a href="https://drafts.csswg.org/css-position-3/#propdef-position">position</a> property is <a href="https://drafts.csswg.org/css-position-3/#valdef-position-fixed">fixed</a>.
             </li>
             <li>
-              E's computed value of the <a href="https://drafts.csswg.org/css-position-3/#propdef-position">position</a> property is <a href="https://drafts.csswg.org/css-position-3/#valdef-position-absolute">absolute</a> and
-              <ul>
-                <li> E's <a href="https://drafts.csswg.org/css-display-3/#containing-block">containing block</a> is an ancestor of the scrollable area or
-                <li> E has a non-zero computed value for any of the
-                  <a href="https://drafts.csswg.org/css-position-3/#propdef-top">top</a>,
-                  <a href="https://drafts.csswg.org/css-position-3/#propdef-right">right</a>,
-                  <a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">bottom</a>, or
-                  <a href="https://drafts.csswg.org/css-position-3/#propdef-left">left</a>
-                  properties.
-              </ul>
+              E's computed value of the <a href="https://drafts.csswg.org/css-position-3/#propdef-position">position</a> property is <a href="https://drafts.csswg.org/css-position-3/#valdef-position-absolute">absolute</a> and E's
+              <a href="https://drafts.csswg.org/css-display-3/#containing-block">containing block</a>
+              is an ancestor of the scrollable area.
+            </li>
+            <li>
+              E's computed value of the <a href="#overflow-anchor">overflow-anchor</a>
+              property is <a href="#overflow-anchor-none">none</a>.
             </li>
           </ul>
         </p>
@@ -157,7 +162,8 @@
       <section>
         <h3>Scroll Adjustment</h3>
         <p>
-          When the anchor node moves, the browser computes its previous location L0 and
+          If an anchor node was selected, then when the anchor node moves,
+          the browser computes its previous location L0 and
           its new location L1 in the coordinate space of the scrolling content. It then
           reads the current scroll position S0 and computes a new scroll position S1:
         </p>
@@ -182,60 +188,54 @@
           the anchor node has moved. These are:
           <ul>
             <li>
-              When 20 consecutive scroll anchoring adjustments have already occurred
-              (with no intervening non-anchoring scrolls).
-            </li>
-            <li>
-              When the scroll anchoring adjustment that would occur is the exact
-              inverse of the most recent scroll anchoring adjustment, and is
-              identical to the one before that. For example, given the following
-              movements of the anchor node:
-              <ol>
-                <li>50 px downward
-                <li>50 px upward
-                <li>50 px downward
-              </ol>
-              The first two will produce scroll anchoring adjustments, but the
-              third will not.
+              When the DOM changes that caused the adjustment include changes to the
+              computed values of properties affecting the position of elements, on
+              elements in the path from the anchor node to the scrollable element (or
+              document), inclusive of both.
+              <p class="issue">
+                Need a clearer specification of which properties trigger this condition.
+              </p>
             </li>
           </ul>
         </div>
       </section>
     </section>
     <section>
-      <h2>Opt-out API</h2>
+      <h2>Exclusion API</h2>
       <p>
         Scroll anchoring aims to be the default mode of behavior when launched, so that
-        users benefit from it even on legacy content. Scroll anchoring can be disabled in
-        part or all of a webpage using a CSS property <code>overflow-anchor</code> which
-        applies to scrollable elements and supports the following values:
+        users benefit from it even on legacy content. A CSS property
+        <dfn id="overflow-anchor"><code>overflow-anchor</code></dfn> can disable
+        scroll anchoring in part or all of a webpage (opt out), or exclude portions
+        of the DOM from the anchor node selection algorithm.
+        This property supports the following values when applied to an element E:
       </p>
       <ul>
         <li>
-            <code>overflow-anchor: visible</code> causes a scrollable area to follow the content
-            within its viewport, using the <a href="#anchoring-algorithm" id="ref-for-anchoring-algorithm-1">scroll anchoring algorithm</a>.
+            <dfn><code>overflow-anchor: visible</code></dfn> declares that the DOM subtree
+            rooted at E is eligible to participate in the <a href="#anchoring-algorithm"
+            id="ref-for-anchoring-algorithm-1">anchor node selection algorithm</a>
+            for any scrollable area created by E or an ancestor of E.
         </li>
         <li>
-            <code>overflow-anchor: none</code> causes a scrollable area to maintain its absolute
-            scroll position when content changes. This was the default behavior prior to
-            the introduction of scroll anchoring.
+            <dfn id="overflow-anchor-none"><code>overflow-anchor: none</code></dfn>
+            declares that the DOM subtree rooted at E is <em>not</em> eligible to
+            participate in the <a href="#anchoring-algorithm"
+            id="ref-for-anchoring-algorithm-1">anchor node selection algorithm</a>
+            for any scrollable area created by E or an ancestor of E.
         </li>
         <li>
-            <code>overflow-anchor: auto</code> invokes the user agent's default behavior for the
-            scrollable area. With the launch of scroll anchoring this will be equivalent
+            <dfn><code>overflow-anchor: auto</code></dfn> invokes the user agent's default behavior for the
+            element. With the launch of scroll anchoring this will be equivalent
             to <code>visible</code>, but is subject to future modification.
         </li>
       </ul>
-      <p>
-        The behavior of the document-level scrollable area is based on the computed
-        <code>overflow-anchor</code> style of the viewport-defining element (<code>html</code> or <code>body</code>).
-      </p>
-      <p>
+      <div class="note">
         The <code>overflow-anchor</code> property is also proposed (with different values) for
-        [CSS Sticky Scrollbars](http://tabatkins.github.io/specs/css-sticky-scrollbars/).
+        <a href="http://tabatkins.github.io/specs/css-sticky-scrollbars/">CSS Sticky Scrollbars</a>.
         This feature is distinct from scroll anchoring, but shares the notion of
         adjusting scroll position in response to content changes.
-      </p>
+      </div>
       <p>
         The <code>overflow-anchor</code> property is not inherited.
       </p>


### PR DESCRIPTION
Update spec and explainer for SANACLAP and exclusion API.

Also remove specification of 20-adjustment limit, bounce suppression, and
exclusion of position:absolute with non-zero offset, and add explainer comments
about open questions (layout-affecting properties, opt-in API, unconditional
exclusion of position:absolute, remaining issues with feedback loops).